### PR TITLE
fix: bug in the dfs logic

### DIFF
--- a/src/app/services/item_service.py
+++ b/src/app/services/item_service.py
@@ -228,7 +228,7 @@ def get_item_by_id_dfs_iterative(
 
                     for task in lab.tasks:
                         counter += 1
-                        if lab.id == item_id:
+                        if task.id == item_id:
                             return FoundItem(task, counter)
 
                         for step in task.steps:


### PR DESCRIPTION
- task.id was never checked
## Summary
Edited this:
for task in lab.tasks:
                        counter += 1
                        if lab.id == item_id:
                            return FoundItem(task, counter)

to this:
for task in lab.tasks:
                        counter += 1
                        if task.id == item_id:
                            return FoundItem(task, counter)


- Closes #2 

---

## Checklist

- [X] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [X] I see `base: main` <- `compare: <branch-name>` above the PR title.
- [X] I edited the line `- Closes #<issue-number>`.
- [X] I wrote clear commit messages.
- [X] I reviewed my own diff before requesting review.
- [X] I understand the changes I’m submitting.
